### PR TITLE
Include astop stack light behavior in fms whitepaper

### DIFF
--- a/source/fms-whitepaper/fms-whitepaper.rst
+++ b/source/fms-whitepaper/fms-whitepaper.rst
@@ -207,15 +207,15 @@ Team Stack Lights
 
 On the field are located 6 stack lights, one per team. Each stack light contains two LED sections equal to the alliance color (red or blue), and an additional amber LED used to indicate Emergency Stop status. Below is a table representing the state of the stack lights and what they indicate.
 
-+----------+--------------------------------------------+----------------------------+
-|          | Alliance Color                             | Amber Color                |
-+----------+--------------------------------------------+----------------------------+
-| Flashing | No connection to robot or station bypassed | N/A                        |
-+----------+--------------------------------------------+----------------------------+
-| Solid    | Robot Enabled                              | Estop pressed/enabled      |
-+----------+--------------------------------------------+----------------------------+
-| Off      | Connection Established to Robot            | Estop not pressed/disabled |
-+----------+--------------------------------------------+----------------------------+
++----------+--------------------------------------------+--------------------------------------------------+
+|          | Alliance Color                             | Amber Color                                      |
++----------+--------------------------------------------+--------------------------------------------------+
+| Flashing | No connection to robot or station bypassed | Astop pressed/enabled (during autonomous period) |
++----------+--------------------------------------------+--------------------------------------------------+
+| Solid    | Robot Enabled                              | Estop pressed/enabled                            |
++----------+--------------------------------------------+--------------------------------------------------+
+| Off      | Connection Established to Robot            | Estop not pressed/disabled                       |
++----------+--------------------------------------------+--------------------------------------------------+
 
 Field Stack Light
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Per section 5.6.2 of the 2024 game manual, there is now a state associated with the blinking amber LED in the team stack lights

> - A-Stop/E-stop LED
>     - Solid: the ROBOT is DISABLED due to a press of the team E-stop button, the FIELD E-stop
> button, or by the scorekeeper via the FMS.
>     - Blinking: the ROBOT is DISABLED for the remainder of AUTO due to a press of the team
> A-Stop button.
>     - Off: the ROBOT is not DISABLED by the FIELD.